### PR TITLE
fix: add position absolute to MenuBarExtraView to avoid shifting view

### DIFF
--- a/src/MenuBarExtraView.tsx
+++ b/src/MenuBarExtraView.tsx
@@ -1,0 +1,19 @@
+import { StyleSheet } from 'react-native';
+import React from 'react';
+import MenubarExtraViewNativeComponent, {
+  type NativeProps,
+} from './MenubarExtraViewNativeComponent';
+
+const MenuBarExtraView = (props: NativeProps) => {
+  return (
+    <MenubarExtraViewNativeComponent style={styles.container} {...props} />
+  );
+};
+
+export default MenuBarExtraView;
+
+const styles = StyleSheet.create({
+  container: {
+    position: 'absolute',
+  },
+});

--- a/src/MenubarExtraViewNativeComponent.ts
+++ b/src/MenubarExtraViewNativeComponent.ts
@@ -5,7 +5,7 @@ if (Platform.OS !== 'macos') {
   throw new Error('react-native-menubar-extra is only supported on macOS.');
 }
 
-interface NativeProps extends ViewProps {
+export interface NativeProps extends ViewProps {
   /**
    * Name of SF Symbol as string that will appear in system status bar.
    */

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,3 +1,3 @@
-export { default as MenubarExtraView } from './MenubarExtraViewNativeComponent';
+export { default as MenubarExtraView } from './MenuBarExtraView';
 export { default as MenuBarExtraItem } from './MenuBarExtraItemNativeComponent';
 export { default as MenuBarExtraSeparator } from './MenuBarExtraSeparatorNativeComponent';


### PR DESCRIPTION
This PR adds position absolute to the MenuBarExtraView which prevents it from shifting the layout in the rest of the app