### PR TITLE
feat: add title prop to MenuBarExtraView to allow displaying status title

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,10 @@ For more advanced example check out the [example](https://github.com/okwasniewsk
 
 Container view that sets up root menu.
 
-| Prop   | Description                                                                                                   |
-| ------ | ------------------------------------------------------------------------------------------------------------- |
-| `icon` | Name of [SF Symbol](https://developer.apple.com/sf-symbols/) as string that will appear in system status bar. |
+| Prop    | Description                                                                                                   |
+| ------- | ------------------------------------------------------------------------------------------------------------- |
+| `title` | Title that will appear next to icon in system status bar.                                                     |
+| `icon`  | Name of [SF Symbol](https://developer.apple.com/sf-symbols/) as string that will appear in system status bar. |
 
 **Important**: Don't pass other types of components as children as it will break the indexing in the menu.
 

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -9,7 +9,7 @@ import {
 
 const MenuBar = () => {
   return (
-    <MenubarExtraView icon="car">
+    <MenubarExtraView icon="car" title="Hey!">
       <MenuBarExtraItem
         title="First item"
         icon="paperplane"

--- a/macos/Fabric/RNMenuBarExtraView.mm
+++ b/macos/Fabric/RNMenuBarExtraView.mm
@@ -58,12 +58,12 @@ using namespace facebook::react;
     const auto &newViewProps = *std::static_pointer_cast<MenubarExtraViewProps const>(props);
     
     if (oldViewProps.icon != newViewProps.icon) {
-        [self updateIcon:[NSString stringWithCString:newViewProps.icon.c_str() encoding:[NSString defaultCStringEncoding]]];
+        [self updateIcon:[NSString stringWithUTF8String:newViewProps.icon.c_str()]];
     }
     
     if (oldViewProps.title != newViewProps.title) {
         if (_statusBarItem.button) {
-            _statusBarItem.button.title = [NSString stringWithCString:newViewProps.title.c_str() encoding:[NSString defaultCStringEncoding]];
+            _statusBarItem.button.title = [NSString stringWithUTF8String:newViewProps.title.c_str()];
         }
     }
     

--- a/macos/Fabric/RNMenuBarExtraView.mm
+++ b/macos/Fabric/RNMenuBarExtraView.mm
@@ -61,6 +61,12 @@ using namespace facebook::react;
         [self updateIcon:[NSString stringWithCString:newViewProps.icon.c_str() encoding:[NSString defaultCStringEncoding]]];
     }
     
+    if (oldViewProps.title != newViewProps.title) {
+        if (_statusBarItem.button) {
+            _statusBarItem.button.title = [NSString stringWithCString:newViewProps.title.c_str() encoding:[NSString defaultCStringEncoding]];
+        }
+    }
+    
     [super updateProps:props oldProps:oldProps];
 }
 

--- a/macos/MenuBarExtraView.m
+++ b/macos/MenuBarExtraView.m
@@ -38,6 +38,11 @@
     if ([changedProps containsObject:@"icon"]) {
         [self updateIcon:self.icon];
     }
+    if ([changedProps containsObject:@"title"]) {
+        if (_statusBarItem.button) {
+            _statusBarItem.button.title = _title;
+        }
+    }
 }
 
 - (void)insertReactSubview:(NSView *)subview atIndex:(NSInteger)atIndex {

--- a/macos/MenubarExtraView.h
+++ b/macos/MenubarExtraView.h
@@ -4,5 +4,6 @@
 @interface MenuBarExtraView : RCTPlatformView
 
 @property(nonatomic) NSString* icon;
+@property(nonatomic) NSString* title;
 
 @end

--- a/macos/MenubarExtraViewManager.m
+++ b/macos/MenubarExtraViewManager.m
@@ -11,6 +11,7 @@
 RCT_EXPORT_MODULE(MenubarExtraView)
 
 RCT_EXPORT_VIEW_PROPERTY(icon, NSString)
+RCT_EXPORT_VIEW_PROPERTY(title, NSString)
 
 - (NSView *)view
 {

--- a/src/MenubarExtraViewNativeComponent.ts
+++ b/src/MenubarExtraViewNativeComponent.ts
@@ -7,9 +7,13 @@ if (Platform.OS !== 'macos') {
 
 export interface NativeProps extends ViewProps {
   /**
+   * Title that will appear next to icon in system status bar.
+   */
+  title?: string;
+  /**
    * Name of SF Symbol as string that will appear in system status bar.
    */
-  icon: string;
+  icon?: string;
 }
 
 export default codegenNativeComponent<NativeProps>('MenubarExtraView');


### PR DESCRIPTION
This PR adds feature that allows you to specify `title` prop for `MenuBarExtraView`

<img width="245" alt="Screenshot 2023-09-24 at 11 49 21" src="https://github.com/okwasniewski/react-native-menubar-extra/assets/52801365/bafa6d02-32d5-4e26-9fe3-c08f4623d0ca">
