### PR TITLE
feat: implement keyEquivalent & keyEquivalentModifierMask props

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,13 @@ Container view that sets up root menu.
 
 ### `MenuBarExtraItem`
 
-| Prop          | Description                                                                                                        |
-| ------------- | ------------------------------------------------------------------------------------------------------------------ |
-| `title`       | The menu item's title                                                                                              |
-| `icon`        | Name of [SF Symbol](https://developer.apple.com/sf-symbols/) as string that will be rendered next to item's title. |
-| `onItemClick` | Callback that is called after clicking on menu item.                                                               |
+| Prop                        | Description                                                                                                        |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `title`                     | The menu item's title                                                                                              |
+| `icon`                      | Name of [SF Symbol](https://developer.apple.com/sf-symbols/) as string that will be rendered next to item's title. |
+| `onItemClick`               | Callback that is called after clicking on menu item.                                                               |
+| `keyEquivalent`             | The menu item’s unmodified key equivalent. For example: "1" or "A".                                                |
+| `keyEquivalentModifierMask` | The menu item’s keyboard equivalent modifiers. Default: `COMMAND`                                                  |
 
 ### `MenuBarExtraSeparator`
 

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -13,6 +13,8 @@ const MenuBar = () => {
       <MenuBarExtraItem
         title="First item"
         icon="paperplane"
+        keyEquivalent="1"
+        keyEquivalentModifierMask="CONTROL"
         onItemPress={() => {
           console.log('First item');
         }}

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -14,7 +14,7 @@ const MenuBar = () => {
         title="First item"
         icon="paperplane"
         keyEquivalent="1"
-        keyEquivalentModifierMask="CONTROL"
+        keyEquivalentModifierMask="OPTION"
         onItemPress={() => {
           console.log('First item');
         }}
@@ -32,6 +32,8 @@ const MenuBar = () => {
       <MenuBarExtraItem
         title="Second item"
         icon="eraser"
+        keyEquivalent="2"
+        keyEquivalentModifierMask="SHIFT"
         onItemPress={() => console.log('Second item')}
       />
       <MenuBarExtraSeparator />

--- a/macos/Fabric/RNMenuBarExtraItem.mm
+++ b/macos/Fabric/RNMenuBarExtraItem.mm
@@ -48,14 +48,23 @@ using namespace facebook::react;
     const auto &newViewProps = *std::static_pointer_cast<MenuBarExtraItemViewProps const>(props);
     
     if (oldViewProps.title != newViewProps.title) {
-        _menuItem.title = [NSString stringWithCString:newViewProps.title.c_str() encoding:[NSString defaultCStringEncoding]];
+        _menuItem.title = [NSString stringWithUTF8String:newViewProps.title.c_str()];
     }
     
     if (oldViewProps.icon != newViewProps.icon) {
         if (@available(macOS 11.0, *)) {
-            NSString *iconName = [NSString stringWithCString:newViewProps.icon.c_str() encoding:[NSString defaultCStringEncoding]];
+            NSString *iconName = [NSString stringWithUTF8String:newViewProps.icon.c_str()];
             _menuItem.image = [NSImage imageWithSystemSymbolName:iconName accessibilityDescription:@""];
         }
+    }
+    
+    if (oldViewProps.keyEquivalent != newViewProps.keyEquivalent) {
+        _menuItem.keyEquivalent = [NSString stringWithUTF8String:newViewProps.keyEquivalent.c_str()];
+    }
+    
+    if (oldViewProps.keyEquivalentModifierMask != newViewProps.keyEquivalentModifierMask) {
+        NSEventModifierFlags eventModifierFlags = KeyEquivalentModifierMaskToNSEventModifierFlags(newViewProps.keyEquivalentModifierMask);
+        _menuItem.keyEquivalentModifierMask = eventModifierFlags;
     }
 
     [super updateProps:props oldProps:oldProps];
@@ -93,6 +102,27 @@ using namespace facebook::react;
 
 - (NSMenuItem *)getItem {
     return _menuItem;
+}
+
+NSEventModifierFlags KeyEquivalentModifierMaskToNSEventModifierFlags(MenuBarExtraItemViewKeyEquivalentModifierMask modifierMask) {
+    switch (modifierMask) {
+        case MenuBarExtraItemViewKeyEquivalentModifierMask::COMMAND:
+            return NSEventModifierFlagCommand;
+        case MenuBarExtraItemViewKeyEquivalentModifierMask::CONTROL:
+            return NSEventModifierFlagControl;
+        case MenuBarExtraItemViewKeyEquivalentModifierMask::CAPS_LOCK:
+            return NSEventModifierFlagCapsLock;
+        case MenuBarExtraItemViewKeyEquivalentModifierMask::SHIFT:
+            return NSEventModifierFlagShift;
+        case MenuBarExtraItemViewKeyEquivalentModifierMask::NUMERIC_PAD:
+            return NSEventModifierFlagNumericPad;
+        case MenuBarExtraItemViewKeyEquivalentModifierMask::HELP:
+            return NSEventModifierFlagHelp;
+        case MenuBarExtraItemViewKeyEquivalentModifierMask::FUNCTION:
+            return NSEventModifierFlagFunction;
+        case MenuBarExtraItemViewKeyEquivalentModifierMask::OPTION:
+            return NSEventModifierFlagOption;
+    }
 }
 
 Class<RCTComponentViewProtocol> MenuBarExtraItemViewCls(void)

--- a/macos/MenuBarExtra+RCTConvert.m
+++ b/macos/MenuBarExtra+RCTConvert.m
@@ -1,0 +1,21 @@
+#import <React/RCTConvert.h>
+#import <React/RCTViewManager.h>
+
+@implementation RCTConvert (MenuBarExtraTypes)
+
+RCT_ENUM_CONVERTER(
+   NSEventModifierFlags,
+    (@{
+      @"CAPS_LOCK" : @(NSEventModifierFlagCapsLock),
+      @"SHIFT" : @(NSEventModifierFlagShift),
+      @"CONTROL" : @(NSEventModifierFlagControl),
+      @"OPTION" : @(NSEventModifierFlagOption),
+      @"COMMAND" : @(NSEventModifierFlagCommand),
+      @"NUMERIC_PAD" : @(NSEventModifierFlagNumericPad),
+      @"HELP": @(NSEventModifierFlagHelp),
+      @"FUNCTION": @(NSEventModifierFlagFunction),
+    }),
+    NSEventModifierFlagCommand,
+    unsignedIntegerValue)
+
+@end

--- a/macos/MenuBarExtraItem.h
+++ b/macos/MenuBarExtraItem.h
@@ -9,6 +9,8 @@
 
 @property(nonatomic) NSString* title;
 @property(nonatomic) NSString* icon;
+@property(nonatomic) NSString* keyEquivalent;
+@property(nonatomic) NSEventModifierFlags keyEquivalentModifierMask;
 @property(nonatomic, strong) NSMenuItem* menuItem;
 @property(nonatomic, copy) RCTDirectEventBlock onItemPress;
 

--- a/macos/MenuBarExtraItem.m
+++ b/macos/MenuBarExtraItem.m
@@ -36,6 +36,12 @@
             _menuItem.image = [NSImage imageWithSystemSymbolName:_icon accessibilityDescription:@""];
         }
     }
+    if ([changedProps containsObject:@"keyEquivalent"]) {
+        _menuItem.keyEquivalent = _keyEquivalent;
+    }
+    if ([changedProps containsObject:@"keyEquivalentModifierMask"]) {
+        _menuItem.keyEquivalentModifierMask = _keyEquivalentModifierMask;
+    }
 }
 
 

--- a/macos/MenuBarExtraItemViewManager.m
+++ b/macos/MenuBarExtraItemViewManager.m
@@ -11,6 +11,8 @@ RCT_EXPORT_MODULE(MenuBarExtraItemView)
 
 RCT_EXPORT_VIEW_PROPERTY(title, NSString)
 RCT_EXPORT_VIEW_PROPERTY(icon, NSString)
+RCT_EXPORT_VIEW_PROPERTY(keyEquivalent, NSString)
+RCT_EXPORT_VIEW_PROPERTY(keyEquivalentModifierMask, NSEventModifierFlags)
 RCT_EXPORT_VIEW_PROPERTY(onItemPress, RCTDirectEventBlock)
 
 - (NSView *)view {

--- a/src/MenuBarExtraItemNativeComponent.ts
+++ b/src/MenuBarExtraItemNativeComponent.ts
@@ -1,10 +1,23 @@
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 import { Platform, type ViewProps } from 'react-native';
-import type { DirectEventHandler } from 'react-native/Libraries/Types/CodegenTypes';
+import type {
+  DirectEventHandler,
+  WithDefault,
+} from 'react-native/Libraries/Types/CodegenTypes';
 
 if (Platform.OS !== 'macos') {
   throw new Error('react-native-menubar-extra is only supported on macOS.');
 }
+
+type ModifierKey =
+  | 'CAPS_LOCK'
+  | 'SHIFT'
+  | 'CONTROL'
+  | 'OPTION'
+  | 'COMMAND'
+  | 'NUMERIC_PAD'
+  | 'HELP'
+  | 'FUNCTION';
 
 interface NativeProps extends ViewProps {
   /**
@@ -19,6 +32,15 @@ interface NativeProps extends ViewProps {
    * Callback that is called after clicking on menu item.
    */
   onItemPress?: DirectEventHandler<undefined>;
+  /**
+   * The menu item’s unmodified key equivalent.
+   * For example: "1" or "A".
+   */
+  keyEquivalent?: string;
+  /**
+   * The menu item’s keyboard equivalent modifiers.
+   */
+  keyEquivalentModifierMask?: WithDefault<ModifierKey, 'COMMAND'>;
 }
 
 export default codegenNativeComponent<NativeProps>('MenuBarExtraItemView');


### PR DESCRIPTION
This PR implements `keyEquivalent` and `keyEquivalentModifierMask` prop for both architectures.

<img width="222" alt="Screenshot 2023-09-25 at 21 39 26" src="https://github.com/okwasniewski/react-native-menubar-extra/assets/52801365/35841aff-aac0-45d2-a2fc-6ce908188cb6">
